### PR TITLE
Update CI workflow and README badges

### DIFF
--- a/.github/workflows/python-lib.yaml
+++ b/.github/workflows/python-lib.yaml
@@ -28,10 +28,3 @@ jobs:
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Check files
         run: poetry run pre-commit run --all-files
-      - name: Report test coverage to Code Climate
-        uses: paambaati/codeclimate-action@v6.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageLocations: coverage.xml:coverage.py
-        if: ${{ github.ref == 'refs/heads/main' && matrix.python-version == '3.13' }}

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Trip Advisor Dataset Loader
 ===========================
 
-|GPLv3| |Build Status| |wercker status| |Release| |PyPi| |Japanese|
+|GPLv3| |Build Status| |Release| |PyPi| |Japanese|
 
 |Logo|
 
@@ -88,10 +88,8 @@ using this package:
 
 .. |GPLv3| image:: https://img.shields.io/badge/license-GPLv3-blue.svg
    :target: https://www.gnu.org/copyleft/gpl.html
-.. |Build Status| image:: https://travis-ci.org/rgmining/tripadvisor.svg?branch=master
-   :target: https://travis-ci.org/rgmining/tripadvisor
-.. |wercker status| image:: https://app.wercker.com/status/815b060cc2fa911215674efdc1078d50/s/master
-   :target: https://app.wercker.com/project/byKey/815b060cc2fa911215674efdc1078d50
+.. |Build Status| image:: https://github.com/rgmining/tripadvisor/actions/workflows/python-lib.yaml/badge.svg
+   :target: https://github.com/rgmining/tripadvisor/actions/workflows/python-lib.yaml
 .. |Release| image:: https://img.shields.io/badge/release-0.5.6-brightgreen.svg
    :target: https://github.com/rgmining/tripadvisor/releases/tag/v0.5.6
 .. |PyPi| image:: https://img.shields.io/badge/pypi-0.5.6-brightgreen.svg


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- **Removed Code Climate coverage reporting:** Simplifies the GitHub Actions workflow by removing the step for reporting test coverage to Code Climate. This step was specific to the main branch and Python 3.13.
- **Updated README badges:** Replaced outdated Travis CI and Wercker badges with a GitHub Actions badge for build status, ensuring the README reflects the current CI workflow. Removed the outdated Wercker badge entirely.

